### PR TITLE
Add facility to ignore messages including certain terms

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ const monitoredChannels = { // channels you want to monitor ALL messages from AL
   [myUsername]: true
 }
 const monitoredTerms = [ myUsername ] // array of words, regex, etc you want to be notified of in joined channels
+const ignoredTerms = [] // opposite of the above: array of words, regex, etc you want to *not* be notified of even in monitored channels
+
 const { chat } = new TwitchJs({ log: { level: 'silent' } })
 
 // remove other listeners
@@ -27,6 +29,7 @@ chat.connect().then(() => {
   chat.on(PARSE_ERROR_ENCOUNTERED, () => {})
   chat.on(PRIVATE_MESSAGE, ({ channel, message, username }) => {
     if (ignoredUsers[username]) return
+    if (includesIgnoredTerm(message)) return
     if (isInMonitoredChannel(channel) || includesMonitoredTerm(message)) {
       return sendIFTTTNotification(`${channel}:\t${username}: ${message}\n`)
     }
@@ -37,6 +40,8 @@ chat.connect().then(() => {
 
 const includesMonitoredTerm = (message) => monitoredTerms.some((term) => message.match(term))
 const isInMonitoredChannel = (channel) => monitoredChannels[channel] || monitoredChannels[stripHash(channel)]
+const includesIgnoredTerm = (message) => ignoredTerms.some((term) => message.match(term))
+
 const sendIFTTTNotification = (message) => {
   try {
     const url = `https://maker.ifttt.com/trigger/${EVENT_NAME}/with/key/${IFTTT_KEY}`

--- a/index.js
+++ b/index.js
@@ -21,7 +21,10 @@ const monitoredChannels = { // channels you want to monitor ALL messages from AL
 const monitoredTerms = [ myUsername ] // array of words, regex, etc you want to be notified of in joined channels
 const ignoredTerms = [] // opposite of the above: array of words, regex, etc you want to *not* be notified of even in monitored channels
 
-const { chat } = new TwitchJs({ log: { level: 'silent' } })
+const { chat } = new TwitchJs({
+  log: { level: 'silent' },
+  token: '',
+})
 
 // remove other listeners
 chat.removeAllListeners()


### PR DESCRIPTION
Controlled by an array analogous to but opposite of `monitoredTerms`, to
which one might add elements such as, eg.,

    /^\s*!butt\s*$/i

if you dont want to read buttsbot invocations.